### PR TITLE
#59 okteto contextを使うように修正

### DIFF
--- a/.github/workflows/okteto.deploy.yaml
+++ b/.github/workflows/okteto.deploy.yaml
@@ -17,7 +17,7 @@ jobs:
         uses: actions/checkout@v3
       - name: Install okteto
         run: curl https://get.okteto.com -sSfL | sh
-      - name: Okteto login
-        run: okteto login --token ${{ secrets.OKTETO_TOKEN }}
-      - name: Okteto deploy
+      - name: Context okteto
+        run: okteto context use https://cloud.okteto.com --token ${{ secrets.OKTETO_TOKEN }}
+      - name: Deploy okteto
         run: okteto deploy --namespace morning-night-dreamer


### PR DESCRIPTION
@Shitomo 

参考通知

`okteto login`が deprecatedで使えなくなったので修正しました。

https://www.okteto.com/docs/reference/cli/#context