### PR TITLE
#97 livenessProbeを設定

### DIFF
--- a/charts/app-api/templates/deployment.yaml
+++ b/charts/app-api/templates/deployment.yaml
@@ -66,6 +66,12 @@ spec:
                   key: firebase-secret
             - name: FIREBASE_API_ENDPOINT
               value: https://identitytoolkit.googleapis.com
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: 8080
+            initialDelaySeconds: 10
+            periodSeconds: 10
           resources:
             limits:
               cpu: "1"

--- a/charts/app-core/templates/deployment.yaml
+++ b/charts/app-core/templates/deployment.yaml
@@ -39,6 +39,11 @@ spec:
                 secretKeyRef:
                   name: platform-secret-newrelic-license
                   key: newrelic-license
+          livenessProbe:
+            grpc:
+              port: 8080
+            initialDelaySeconds: 10
+            periodSeconds: 10
           resources:
             limits:
               cpu: "1"


### PR DESCRIPTION
@Shitomo 

livenessProbe（コンテナの生存チェック機能）を設定しました。
本当は外部サービスとの通信等を挟む必要がありますが、一旦コンテナが起動しているかどうかだけチェックしています。